### PR TITLE
Fixing a compatibility error with Django 2.0

### DIFF
--- a/src/usertools/admin.py
+++ b/src/usertools/admin.py
@@ -15,7 +15,7 @@ from django.contrib.admin.utils import flatten_fieldsets
 from django.core.exceptions import PermissionDenied
 try:
     from django.core.urlresolvers import reverse
-except ModuleNotFoundError:
+except (ImportError, ModuleNotFoundError,):
     from django.urls import reverse
 from django.core.mail import send_mail
 from django.db import transaction

--- a/src/usertools/admin.py
+++ b/src/usertools/admin.py
@@ -15,7 +15,7 @@ from django.contrib.admin.utils import flatten_fieldsets
 from django.core.exceptions import PermissionDenied
 try:
     from django.core.urlresolvers import reverse
-except (ImportError, ModuleNotFoundError,):
+except ImportError:
     from django.urls import reverse
 from django.core.mail import send_mail
 from django.db import transaction


### PR DESCRIPTION
Django changed the location on the reverse method in v 2.0, importing it was throwing a ModuleNotFound exception